### PR TITLE
Fixed calling methods

### DIFF
--- a/lib/class.go
+++ b/lib/class.go
@@ -530,7 +530,7 @@ func Clear(obj Object) error {
 
 var (
 	fieldLock sync.RWMutex
-	fields []reflect.StructField
+	fields    []reflect.StructField
 )
 
 func registerField(field reflect.StructField) C.int {
@@ -579,27 +579,27 @@ type goMethod struct {
 // signatures (hence the names are one greater than the number of arguments
 // taken).
 var (
-	pyInitFunc        = func(*Tuple, *Dict) error(nil)
+	pyInitFunc        = (func(*Tuple, *Dict) error)(nil)
 	pyVoidFunc        = (func())(nil)
-	pyReprFunc        = func() string(nil)
-	pyLenFunc         = func() int64(nil)
-	pyHashFunc        = func() (uint32, error)(nil)
-	pyInquiryFunc     = func() (bool, error)(nil)
-	pyUnaryFunc       = func() (Object, error)(nil)
-	pyBinaryFunc      = func(Object) (Object, error)(nil)
-	pyTernaryFunc     = func(a, b Object) (Object, error)(nil)
-	pyBinaryCallFunc  = func(*Tuple) (Object, error)(nil)
-	pyTernaryCallFunc = func(*Tuple, *Dict) (Object, error)(nil)
-	pyCompareFunc     = func(Object) (int, error)(nil)
-	pyRichCmpFunc     = func(Object, Op) (Object, error)(nil)
-	pyObjObjArgFunc   = func(a, b Object) error(nil)
-	pySsizeArgFunc    = func(int64) (Object, error)(nil)
-	pySsizeObjArgFunc = func(int64, Object) error(nil)
-	pyObjObjFunc      = func(Object) (bool, error)(nil)
-	pyGetAttrFunc     = func(string) (Object, error)(nil)
-	pyGetAttrObjFunc  = func(Object) (Object, error)(nil)
-	pySetAttrFunc     = func(string, Object) error(nil)
-	pySetAttrObjFunc  = func(Object, Object) error(nil)
+	pyReprFunc        = (func() string)(nil)
+	pyLenFunc         = (func() int64)(nil)
+	pyHashFunc        = (func() (uint32, error))(nil)
+	pyInquiryFunc     = (func() (bool, error))(nil)
+	pyUnaryFunc       = (func() (Object, error))(nil)
+	pyBinaryFunc      = (func(Object) (Object, error))(nil)
+	pyTernaryFunc     = (func(a, b Object) (Object, error))(nil)
+	pyBinaryCallFunc  = (func(*Tuple) (Object, error))(nil)
+	pyTernaryCallFunc = (func(*Tuple, *Dict) (Object, error))(nil)
+	pyCompareFunc     = (func(Object) (int, error))(nil)
+	pyRichCmpFunc     = (func(Object, Op) (Object, error))(nil)
+	pyObjObjArgFunc   = (func(a, b Object) error)(nil)
+	pySsizeArgFunc    = (func(int64) (Object, error))(nil)
+	pySsizeObjArgFunc = (func(int64, Object) error)(nil)
+	pyObjObjFunc      = (func(Object) (bool, error))(nil)
+	pyGetAttrFunc     = (func(string) (Object, error))(nil)
+	pyGetAttrObjFunc  = (func(Object) (Object, error))(nil)
+	pySetAttrFunc     = (func(string, Object) error)(nil)
+	pySetAttrObjFunc  = (func(Object, Object) error)(nil)
 )
 
 var methodMap = map[string]goMethod{
@@ -740,7 +740,8 @@ func (c *Class) Create() (*Type, error) {
 			continue
 		}
 		t := m.Func.Type()
-		f := unsafe.Pointer(m.Func.Pointer())
+		fi := unsafe.Pointer(m.Func.Pointer())
+		f := unsafe.Pointer(&fi)
 		fn := fmt.Sprintf("%s.%s", typ.Elem().Name(), m.Name)
 		meth, ok := methodMap[m.Name]
 		if ok {
@@ -766,7 +767,7 @@ func (c *Class) Create() (*Type, error) {
 				return nil, fmt.Errorf("%s: Invalid function signature", fn)
 			}
 		case "PySet":
-			err := methSigMatches(t, func(Object) error(nil))
+			err := methSigMatches(t, (func(Object) error)(nil))
 			if err != nil {
 				C.free(unsafe.Pointer(pyType))
 				return nil, fmt.Errorf("%s: %s", fn, err)
@@ -775,7 +776,7 @@ func (c *Class) Create() (*Type, error) {
 			p.set = f
 			props[parts[1]] = p
 		case "PyGet":
-			err := methSigMatches(t, func() (Object, error)(nil))
+			err := methSigMatches(t, (func() (Object, error))(nil))
 			if err != nil {
 				C.free(unsafe.Pointer(pyType))
 				return nil, fmt.Errorf("%s: %s", fn, err)

--- a/lib/run.go
+++ b/lib/run.go
@@ -17,6 +17,28 @@ const (
 	SingleInput
 )
 
+func RunString(code string, start StartToken, globals, locals Object) (Object, error) {
+	codestr := C.CString(code)
+	defer C.free(unsafe.Pointer(codestr))
+
+	var token C.int
+	switch start {
+	case EvalInput:
+		token = C.Py_eval_input
+	case FileInput:
+		token = C.Py_file_input
+	case SingleInput:
+		token = C.Py_single_input
+	}
+
+	obj := C.PyRun_StringFlags(codestr, token, c(globals), c(locals), nil)
+	if obj == nil {
+		return nil, exception()
+	}
+
+	return newObject(obj), nil
+}
+
 func RunFile(filename string, start StartToken, globals, locals Object) (Object, error) {
 	name := C.CString(filename)
 	defer C.free(unsafe.Pointer(name))

--- a/module_test.go
+++ b/module_test.go
@@ -1,0 +1,89 @@
+package pytesting
+
+import (
+	"github.com/qur/gopy/lib"
+	"testing"
+)
+
+func TestFunction(t *testing.T) {
+	py.Initialize()
+	called := false
+	f := func() (py.Object, error) {
+		called = true
+		return py.None, nil
+	}
+	if m, err := py.InitModule("test", []py.Method{{"test", f, ""}}); err != nil {
+		t.Fatal(err)
+	} else if t2, err := m.Dict().GetItemString("test"); err != nil {
+		t.Fatal(err)
+	} else {
+		t2.Base().CallObject(nil)
+	}
+	if !called {
+		t.Error("Function wasn't called")
+	}
+}
+
+type ExampleClass struct {
+	py.BaseObject
+	called bool
+}
+
+func (e *ExampleClass) PyStr() string {
+	panic("called")
+	return "my test"
+}
+
+var exampleClass = py.Class{
+	Name:    "test.test",
+	Pointer: (*ExampleClass)(nil),
+}
+
+func TestMethod(t *testing.T) {
+	py.Initialize()
+
+	if main, err := py.NewDict(); err != nil {
+		t.Fatal(err)
+	} else if m, err := py.InitModule("test", nil); err != nil {
+		t.Fatal(err)
+	} else if c, err := exampleClass.Create(); err != nil {
+		t.Fatal(err)
+	} else if g, err := py.GetBuiltins(); err != nil {
+		t.Fatal(err)
+	} else if err := main.SetItemString("__builtins__", g); err != nil {
+		t.Fatal(err)
+	} else if err := m.AddObject("test", c); err != nil {
+		t.Fatal(err)
+	} else if _, err := py.RunString("import test; a = test.test()", py.SingleInput, main, nil); err != nil {
+		t.Fatal(err)
+	} else if a, err := main.GetItemString("a"); err != nil {
+		t.Fatal(err)
+	} else if a == py.None || a.Type().String() != "<type 'test.test'>" {
+		t.Error(a.Type().String())
+	}
+}
+
+func TestMethod2(t *testing.T) {
+	py.Initialize()
+	if main, err := py.NewDict(); err != nil {
+		t.Fatal(err)
+	} else if m, err := py.InitModule("test", nil); err != nil {
+		t.Fatal(err)
+	} else if c, err := exampleClass.Create(); err != nil {
+		t.Fatal(err)
+	} else if g, err := py.GetBuiltins(); err != nil {
+		t.Fatal(err)
+	} else if err := main.SetItemString("__builtins__", g); err != nil {
+		t.Fatal(err)
+	} else if err := m.AddObject("test", c); err != nil {
+		t.Fatal(err)
+	} else if _, err := py.RunString("import test; a = test.test().__str__", py.SingleInput, main, nil); err != nil {
+		t.Fatal(err)
+	} else if a, err := main.GetItemString("a"); err != nil {
+		t.Fatal(err)
+	} else {
+		_ = a
+		// Hangs forever...
+		//		t.Log(a.Base().CallObject(nil))
+	}
+}

--- a/module_test.go
+++ b/module_test.go
@@ -29,14 +29,28 @@ type ExampleClass struct {
 	called bool
 }
 
-func (e *ExampleClass) PyStr() string {
+func (e *ExampleClass) Py_Test() (py.Object, error) {
 	panic("called")
-	return "my test"
+}
+
+func (e *ExampleClass) Py_Test2(args *py.Tuple, kwds *py.Dict) (py.Object, error) {
+	if v, err := args.GetItem(0); err != nil {
+		panic(err)
+	} else if i, ok := v.(*py.Int); !ok {
+		panic(v)
+	} else if i.Int() != 10 {
+		panic(i)
+	}
+	panic("called2")
+}
+
+func (e *ExampleClass) PyStr() string {
+	panic("strcalled")
 }
 
 var exampleClass = py.Class{
 	Name:    "test.test",
-	Pointer: (*ExampleClass)(nil),
+	Pointer: &ExampleClass{},
 }
 
 func TestMethod(t *testing.T) {
@@ -77,13 +91,33 @@ func TestMethod2(t *testing.T) {
 		t.Fatal(err)
 	} else if err := m.AddObject("test", c); err != nil {
 		t.Fatal(err)
-	} else if _, err := py.RunString("import test; a = test.test().__str__", py.SingleInput, main, nil); err != nil {
+	} else if _, err := py.RunString("import test; a = test.test()", py.SingleInput, main, nil); err != nil {
 		t.Fatal(err)
 	} else if a, err := main.GetItemString("a"); err != nil {
 		t.Fatal(err)
 	} else {
-		_ = a
-		// Hangs forever...
-		//		t.Log(a.Base().CallObject(nil))
+		type Test struct {
+			m    string
+			pan  string
+			f    string
+			args []interface{}
+		}
+		tests := []Test{
+			{"Test", "called", "", nil},
+			{"Test2", "called2", "i", []interface{}{10}},
+			{"__str__", "strcalled", "", nil},
+		}
+		for _, test := range tests {
+			func() {
+				defer func() {
+					if i := recover(); i == test.pan {
+						t.Log("Success!")
+					} else {
+						t.Error("Paniced for some other reason:", i)
+					}
+				}()
+				a.Base().CallMethod(test.m, test.f, test.args...)
+			}()
+		}
 	}
 }

--- a/run_test.go
+++ b/run_test.go
@@ -1,0 +1,23 @@
+package pytesting
+
+import (
+	"github.com/qur/gopy/lib"
+	"testing"
+)
+
+func TestRunString(t *testing.T) {
+	py.Initialize()
+	if main, err := py.NewDict(); err != nil {
+		t.Fatal(err)
+	} else if g, err := py.GetBuiltins(); err != nil {
+		t.Fatal(err)
+	} else if err := main.SetItemString("__builtins__", g); err != nil {
+		t.Fatal(err)
+	} else if _, err := py.RunString("a = 'hello world!'", py.FileInput, main, nil); err != nil {
+		t.Fatal(err)
+	} else if a, err := main.GetItemString("a"); err != nil {
+		t.Fatal(err)
+	} else if b, ok := a.(*py.String); !ok || b.String() != "hello world!" {
+		t.Error(b, err)
+	}
+}


### PR DESCRIPTION
Hi,

I was having problems calling type methods so put together a couple of tests to figure out what needed changing. The important bit is this:

``` diff
-    f := unsafe.Pointer(m.Func.Pointer())
+    fi := unsafe.Pointer(m.Func.Pointer())
+    f := unsafe.Pointer(&fi)
```

though I've only tested with 

```
$ go version
go version devel +d82ec1b4fb7a Sat Mar 30 22:59:08 2013 -0700 darwin/amd64
```

so don't know how portable this change is.

A more robust solution would probably be to use the interface type rather than unsafe.Pointer, but that's a larger change.
